### PR TITLE
fix: onConfirm TypescriptRenameFile

### DIFF
--- a/lua/typescript.lua
+++ b/lua/typescript.lua
@@ -2707,14 +2707,7 @@ ____exports.removeUnused = makeCommand(SourceActions.SourceRemoveUnusedTs)
 return ____exports
  end,
 ["commands"] = function(...) 
-local ____lualib = require("lualib_bundle")
-local Error = ____lualib.Error
-local RangeError = ____lualib.RangeError
-local ReferenceError = ____lualib.ReferenceError
-local SyntaxError = ____lualib.SyntaxError
-local TypeError = ____lualib.TypeError
-local URIError = ____lualib.URIError
-local __TS__New = ____lualib.__TS__New
+--[[ Generated with https://github.com/TypeScriptToLua/TypeScriptToLua ]]
 local ____exports = {}
 local ____config = require("config")
 local config = ____config.config
@@ -2738,10 +2731,7 @@ ____exports.setupCommands = function(bufnr)
                 {prompt = "New path: ", default = source},
                 function(input)
                     if input == "" or input == source or input == nil then
-                        error(
-                            __TS__New(Error),
-                            0
-                        )
+                        return
                     end
                     renameFile(source, input, {force = opts.bang})
                 end

--- a/lua/typescript.lua
+++ b/lua/typescript.lua
@@ -2734,39 +2734,17 @@ ____exports.setupCommands = function(bufnr)
         "TypescriptRenameFile",
         function(opts)
             local source = vim.api.nvim_buf_get_name(0)
-            local target
-            do
-                local function ____catch(_)
-                    return true
+            vim.ui.input(
+                {prompt = "New path: ", default = source},
+                function(input)
+                    if input == "" or input == source or input == nil then
+                        error(
+                            __TS__New(Error),
+                            0
+                        )
+                    end
+                    renameFile(source, input, {force = opts.bang})
                 end
-                local ____try, ____hasReturned, ____returnValue = pcall(function()
-                    vim.ui.input(
-                        {prompt = "New path: ", default = source},
-                        function(input)
-                            if input == "" or input == source then
-                                error(
-                                    __TS__New(Error),
-                                    0
-                                )
-                            end
-                            target = input
-                        end
-                    )
-                end)
-                if not ____try then
-                    ____hasReturned, ____returnValue = ____catch(____hasReturned)
-                end
-                if ____hasReturned then
-                    return ____returnValue
-                end
-            end
-            if target == "" or target == nil then
-                return
-            end
-            renameFile(
-                vim.api.nvim_buf_get_name(0),
-                target,
-                {force = opts.bang}
             )
         end,
         {bang = true}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -19,7 +19,7 @@ export const setupCommands = (bufnr: number) => {
       const source = vim.api.nvim_buf_get_name(0);
       vim.ui.input({ prompt: "New path: ", default: source }, (input) => {
         if (input === "" || input === source || input === undefined) {
-          throw new Error();
+          return;
         }
         renameFile(source, input, {
           force: opts.bang,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -17,23 +17,13 @@ export const setupCommands = (bufnr: number) => {
     "TypescriptRenameFile",
     (opts) => {
       const source = vim.api.nvim_buf_get_name(0);
-      let target: string | undefined;
-      try {
-        vim.ui.input({ prompt: "New path: ", default: source }, (input) => {
-          if (input === "" || input === source) {
-            throw new Error();
-          }
-          target = input;
+      vim.ui.input({ prompt: "New path: ", default: source }, (input) => {
+        if (input === "" || input === source || input === undefined) {
+          throw new Error();
+        }
+        renameFile(source, input, {
+          force: opts.bang,
         });
-      } catch (_) {
-        return;
-      }
-      if (target === "" || target === undefined) {
-        return;
-      }
-
-      renameFile(vim.api.nvim_buf_get_name(0), target, {
-        force: opts.bang,
       });
     },
     { bang: true }


### PR DESCRIPTION
Hello ! 

First thank you for this plugin, i have been using null-ls for a year now as a typescript dev with LunarVim config.

This PR fixes #3 about TypescriptRenameFile.

The issue was about the tests for target and renameFile that are executed immediately after the input (and not only after confirmation). So the target was always undefined.