### PR TITLE
feat: support go to source definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,19 @@ Lua commands.
   the current buffer and prompt for a rename target, while the Lua version
   requires specifying the full path to a `source` and `target`.
 
+- Go to source definition: `:TypescriptGoToSourceDefinition` /
+  `require("typescript").goToSourceDefinition(winnr)`
+
+  > TypeScript 4.7 contains support for a new experimental editor command called
+  > Go To Source Definition. It’s similar to Go To Definition, but it never
+  > returns results inside declaration files. Instead, it tries to find
+  > corresponding implementation files (like .js or .ts files), and find
+  > definitions there — even if those files are normally shadowed by .d.ts
+  > files.
+
+  The command requires a position and derives it from the current window when
+  using the Vim command or from the given `winnr` when using the Lua API.
+
 ### Handlers
 
 The plugin defines handlers for off-spec methods that are not otherwise

--- a/lua/typescript.lua
+++ b/lua/typescript.lua
@@ -2561,9 +2561,18 @@ return {
 local ____exports = {}
 ____exports.Methods = Methods or ({})
 ____exports.Methods.CODE_ACTION = "textDocument/codeAction"
+____exports.Methods.DEFINITION = "textDocument/definition"
 ____exports.Methods.EXECUTE_COMMAND = "workspace/executeCommand"
 ____exports.TypescriptMethods = TypescriptMethods or ({})
 ____exports.TypescriptMethods.RENAME = "_typescript.rename"
+return ____exports
+ end,
+["types.workspace-commands"] = function(...) 
+--[[ Generated with https://github.com/TypeScriptToLua/TypeScriptToLua ]]
+local ____exports = {}
+____exports.WorkspaceCommands = WorkspaceCommands or ({})
+____exports.WorkspaceCommands.APPLY_RENAME_FILE = "_typescript.applyRenameFile"
+____exports.WorkspaceCommands.GO_TO_SOURCE_DEFINITION = "_typescript.goToSourceDefinition"
 return ____exports
  end,
 ["config"] = function(...) 
@@ -2606,6 +2615,61 @@ ____exports.getClient = function(bufnr)
         end
     end
 end
+____exports.resolveHandler = function(bufnr, method)
+    local client = ____exports.getClient(bufnr)
+    if not client then
+        return
+    end
+    return client.handlers[method] or vim.lsp.handlers[method]
+end
+return ____exports
+ end,
+["execute-command"] = function(...) 
+--[[ Generated with https://github.com/TypeScriptToLua/TypeScriptToLua ]]
+local ____exports = {}
+local ____methods = require("types.methods")
+local Methods = ____methods.Methods
+local ____utils = require("utils")
+local getClient = ____utils.getClient
+____exports.executeCommand = function(bufnr, params, callback)
+    local client = getClient(bufnr)
+    if not client then
+        return false
+    end
+    return client.request(Methods.EXECUTE_COMMAND, params, callback)
+end
+return ____exports
+ end,
+["go-to-source-definition"] = function(...) 
+--[[ Generated with https://github.com/TypeScriptToLua/TypeScriptToLua ]]
+local ____exports = {}
+local ____execute_2Dcommand = require("execute-command")
+local executeCommand = ____execute_2Dcommand.executeCommand
+local ____methods = require("types.methods")
+local Methods = ____methods.Methods
+local ____workspace_2Dcommands = require("types.workspace-commands")
+local WorkspaceCommands = ____workspace_2Dcommands.WorkspaceCommands
+local ____utils = require("utils")
+local getClient = ____utils.getClient
+local resolveHandler = ____utils.resolveHandler
+____exports.goToSourceDefinition = function(____bindingPattern0)
+    local winnr
+    winnr = ____bindingPattern0.winnr
+    local bufnr = vim.api.nvim_win_get_buf(winnr)
+    local client = getClient(bufnr)
+    if not client then
+        return
+    end
+    local positionParams = vim.lsp.util.make_position_params(winnr, client.offset_encoding)
+    local requestOk = executeCommand(
+        bufnr,
+        {command = WorkspaceCommands.GO_TO_SOURCE_DEFINITION, arguments = {positionParams.textDocument.uri, positionParams.position}},
+        resolveHandler(bufnr, Methods.DEFINITION)
+    )
+    if not requestOk then
+        print("failed to go to source definition: tsserver request failed")
+    end
+end
 return ____exports
  end,
 ["rename-file"] = function(...) 
@@ -2618,29 +2682,14 @@ local TypeError = ____lualib.TypeError
 local URIError = ____lualib.URIError
 local __TS__New = ____lualib.__TS__New
 local ____exports = {}
-local ____methods = require("types.methods")
-local Methods = ____methods.Methods
+local ____execute_2Dcommand = require("execute-command")
+local executeCommand = ____execute_2Dcommand.executeCommand
+local ____workspace_2Dcommands = require("types.workspace-commands")
+local WorkspaceCommands = ____workspace_2Dcommands.WorkspaceCommands
 local ____utils = require("utils")
 local debugLog = ____utils.debugLog
-local getClient = ____utils.getClient
 local ____lspconfig = require("lspconfig")
 local util = ____lspconfig.util
-local function sendRequest(sourceBufnr, source, target)
-    local client = getClient(sourceBufnr)
-    if not client then
-        return false
-    end
-    return client.request(
-        Methods.EXECUTE_COMMAND,
-        {
-            command = "_typescript.applyRenameFile",
-            arguments = {{
-                sourceUri = vim.uri_from_fname(source),
-                targetUri = vim.uri_from_fname(target)
-            }}
-        }
-    )
-end
 ____exports.renameFile = function(source, target, opts)
     if opts == nil then
         opts = {}
@@ -2655,7 +2704,16 @@ ____exports.renameFile = function(source, target, opts)
         end
     end
     debugLog((("sending request to rename source " .. source) .. " to target ") .. target)
-    local requestOk = sendRequest(sourceBufnr, source, target)
+    local requestOk = executeCommand(
+        sourceBufnr,
+        {
+            command = WorkspaceCommands.APPLY_RENAME_FILE,
+            arguments = {{
+                sourceUri = vim.uri_from_fname(source),
+                targetUri = vim.uri_from_fname(target)
+            }}
+        }
+    )
     if not requestOk then
         print("failed to rename file: tsserver request failed")
         return
@@ -2770,6 +2828,8 @@ return ____exports
 ["commands"] = function(...) 
 --[[ Generated with https://github.com/TypeScriptToLua/TypeScriptToLua ]]
 local ____exports = {}
+local ____go_2Dto_2Dsource_2Ddefinition = require("go-to-source-definition")
+local goToSourceDefinition = ____go_2Dto_2Dsource_2Ddefinition.goToSourceDefinition
 local ____rename_2Dfile = require("rename-file")
 local renameFile = ____rename_2Dfile.renameFile
 local ____source_2Dactions = require("source-actions")
@@ -2782,7 +2842,7 @@ ____exports.setupCommands = function(bufnr)
         bufnr,
         "TypescriptRenameFile",
         function(opts)
-            local source = vim.api.nvim_buf_get_name(0)
+            local source = vim.api.nvim_buf_get_name(bufnr)
             vim.ui.input(
                 {prompt = "New path: ", default = source},
                 function(input)
@@ -2794,6 +2854,12 @@ ____exports.setupCommands = function(bufnr)
             )
         end,
         {bang = true}
+    )
+    vim.api.nvim_buf_create_user_command(
+        bufnr,
+        "TypescriptGoToSourceDefinition",
+        function() return goToSourceDefinition({winnr = vim.api.nvim_get_current_win()}) end,
+        {}
     )
     vim.api.nvim_buf_create_user_command(
         bufnr,
@@ -2906,6 +2972,11 @@ local setupLsp = ____lsp.setupLsp
 ____exports.setup = function(userOptions)
     setupConfig(userOptions)
     setupLsp()
+end
+do
+    local ____go_2Dto_2Dsource_2Ddefinition = require("go-to-source-definition")
+    local goToSourceDefinition = ____go_2Dto_2Dsource_2Ddefinition.goToSourceDefinition
+    ____exports.goToSourceDefinition = goToSourceDefinition
 end
 do
     local ____rename_2Dfile = require("rename-file")

--- a/lua/typescript.lua
+++ b/lua/typescript.lua
@@ -2664,7 +2664,20 @@ ____exports.goToSourceDefinition = function(____bindingPattern0)
     local requestOk = executeCommand(
         bufnr,
         {command = WorkspaceCommands.GO_TO_SOURCE_DEFINITION, arguments = {positionParams.textDocument.uri, positionParams.position}},
-        resolveHandler(bufnr, Methods.DEFINITION)
+        function(...)
+            local args = {...}
+            local res = args[2]
+            if vim.tbl_isempty(res) then
+                print("failed to go to source definition: no source definitions found")
+                return
+            end
+            local handler = resolveHandler(bufnr, Methods.DEFINITION)
+            if not handler then
+                print("failed to go to source definition: could not resolve definition handler")
+                return
+            end
+            handler(unpack(args))
+        end
     )
     if not requestOk then
         print("failed to go to source definition: tsserver request failed")

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,3 +1,4 @@
+import { goToSourceDefinition } from "@ts/go-to-source-definition";
 import { renameFile } from "@ts/rename-file";
 import {
   addMissingImports,
@@ -11,7 +12,7 @@ export const setupCommands = (bufnr: number) => {
     bufnr,
     "TypescriptRenameFile",
     (opts) => {
-      const source = vim.api.nvim_buf_get_name(0);
+      const source = vim.api.nvim_buf_get_name(bufnr);
       vim.ui.input({ prompt: "New path: ", default: source }, (input) => {
         if (input === "" || input === source || input === undefined) {
           return;
@@ -22,6 +23,13 @@ export const setupCommands = (bufnr: number) => {
       });
     },
     { bang: true }
+  );
+
+  vim.api.nvim_buf_create_user_command(
+    bufnr,
+    "TypescriptGoToSourceDefinition",
+    () => goToSourceDefinition({ winnr: vim.api.nvim_get_current_win() }),
+    {}
   );
 
   vim.api.nvim_buf_create_user_command(

--- a/src/execute-command.ts
+++ b/src/execute-command.ts
@@ -1,0 +1,25 @@
+import { Methods } from "@ts/types/methods";
+import { WorkspaceCommands } from "@ts/types/workspace-commands";
+import { getClient } from "@ts/utils";
+
+export interface ExecuteCommandParams {
+  command: WorkspaceCommands;
+  arguments: unknown[];
+}
+
+export const executeCommand = <T = void>(
+  bufnr: number,
+  params: ExecuteCommandParams,
+  callback?: NvimLsp.Handler<T>
+): boolean => {
+  const client = getClient(bufnr);
+  if (!client) {
+    return false;
+  }
+
+  return client.request<T, ExecuteCommandParams>(
+    Methods.EXECUTE_COMMAND,
+    params,
+    callback
+  );
+};

--- a/src/go-to-source-definition.ts
+++ b/src/go-to-source-definition.ts
@@ -26,7 +26,23 @@ export const goToSourceDefinition = ({ winnr }: Opts) => {
       command: WorkspaceCommands.GO_TO_SOURCE_DEFINITION,
       arguments: [positionParams.textDocument.uri, positionParams.position],
     },
-    resolveHandler(bufnr, Methods.DEFINITION)
+    (...args) => {
+      const res = args[1];
+      if (vim.tbl_isempty(res)) {
+        print("failed to go to source definition: no source definitions found");
+        return;
+      }
+
+      const handler = resolveHandler(bufnr, Methods.DEFINITION);
+      if (!handler) {
+        print(
+          "failed to go to source definition: could not resolve definition handler"
+        );
+        return;
+      }
+
+      handler(...args);
+    }
   );
 
   if (!requestOk) {

--- a/src/go-to-source-definition.ts
+++ b/src/go-to-source-definition.ts
@@ -1,0 +1,35 @@
+import { executeCommand } from "@ts/execute-command";
+import { Methods } from "@ts/types/methods";
+import { WorkspaceCommands } from "@ts/types/workspace-commands";
+import { getClient, resolveHandler } from "@ts/utils";
+import { Location } from "vscode-languageserver-types";
+
+interface Opts {
+  winnr: number;
+}
+
+export const goToSourceDefinition = ({ winnr }: Opts) => {
+  const bufnr = vim.api.nvim_win_get_buf(winnr);
+  const client = getClient(bufnr);
+  if (!client) {
+    return;
+  }
+
+  const positionParams = vim.lsp.util.make_position_params(
+    winnr,
+    client.offset_encoding
+  );
+
+  const requestOk = executeCommand<Location>(
+    bufnr,
+    {
+      command: WorkspaceCommands.GO_TO_SOURCE_DEFINITION,
+      arguments: [positionParams.textDocument.uri, positionParams.position],
+    },
+    resolveHandler(bufnr, Methods.DEFINITION)
+  );
+
+  if (!requestOk) {
+    print("failed to go to source definition: tsserver request failed");
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,6 @@ export const setup = (userOptions: ConfigOptions) => {
   setupLsp();
 };
 
+export { goToSourceDefinition } from "@ts/go-to-source-definition";
 export { renameFile } from "@ts/rename-file";
 export * as actions from "@ts/source-actions";

--- a/src/rename-file.ts
+++ b/src/rename-file.ts
@@ -1,36 +1,11 @@
-import { Methods } from "@ts/types/methods";
-import { debugLog, getClient } from "@ts/utils";
+import { executeCommand } from "@ts/execute-command";
+import { WorkspaceCommands } from "@ts/types/workspace-commands";
+import { debugLog } from "@ts/utils";
 import { util } from "lspconfig";
-
-interface ExecuteCommandParams {
-  command: string;
-  arguments: unknown[];
-}
 
 interface Opts {
   force?: boolean;
 }
-
-const sendRequest = (
-  sourceBufnr: number,
-  source: string,
-  target: string
-): boolean => {
-  const client = getClient(sourceBufnr);
-  if (!client) {
-    return false;
-  }
-
-  return client.request<void, ExecuteCommandParams>(Methods.EXECUTE_COMMAND, {
-    command: "_typescript.applyRenameFile",
-    arguments: [
-      {
-        sourceUri: vim.uri_from_fname(source),
-        targetUri: vim.uri_from_fname(target),
-      },
-    ],
-  });
-};
 
 export const renameFile = (
   source: string,
@@ -52,7 +27,15 @@ export const renameFile = (
   }
 
   debugLog(`sending request to rename source ${source} to target ${target}`);
-  const requestOk = sendRequest(sourceBufnr, source, target);
+  const requestOk = executeCommand(sourceBufnr, {
+    command: WorkspaceCommands.APPLY_RENAME_FILE,
+    arguments: [
+      {
+        sourceUri: vim.uri_from_fname(source),
+        targetUri: vim.uri_from_fname(target),
+      },
+    ],
+  });
   if (!requestOk) {
     print("failed to rename file: tsserver request failed");
     return;

--- a/src/types/methods.ts
+++ b/src/types/methods.ts
@@ -1,5 +1,6 @@
 export enum Methods {
   CODE_ACTION = "textDocument/codeAction",
+  DEFINITION = "textDocument/definition",
   EXECUTE_COMMAND = "workspace/executeCommand",
 }
 

--- a/src/types/nvim.d.ts
+++ b/src/types/nvim.d.ts
@@ -6,11 +6,19 @@ declare namespace NvimLsp {
     range: import("vscode-languageserver-types").Range;
   }
 
+  interface HandlerContext {
+    bufnr: number;
+    client_id: number;
+    method: string;
+    params: Record<string, unknown>;
+  }
+
   type Handler<T = unknown> = (
     this: void,
     err: unknown,
     res: T[],
-    params: unknown
+    ctx: HandlerContext,
+    config: Record<string, unknown>
   ) => void;
   type Handlers = {
     [method: string]: Handler;
@@ -68,6 +76,7 @@ declare namespace Nvim {
 declare namespace vim {
   const inspect: (...args: unknown[]) => void;
   const schedule: (this: void, callback: () => void) => void;
+  const tbl_isempty: (this: void, tbl: unknown[]) => boolean;
   const lsp: {
     handlers: NvimLsp.Handlers;
     buf_get_clients: (

--- a/src/types/workspace-commands.ts
+++ b/src/types/workspace-commands.ts
@@ -1,0 +1,4 @@
+export enum WorkspaceCommands {
+  APPLY_RENAME_FILE = "_typescript.applyRenameFile",
+  GO_TO_SOURCE_DEFINITION = "_typescript.goToSourceDefinition",
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,3 +14,15 @@ export const getClient = (bufnr: number): NvimLsp.Client | undefined => {
     }
   }
 };
+
+export const resolveHandler = (
+  bufnr: number,
+  method: string
+): NvimLsp.Handler | undefined => {
+  const client = getClient(bufnr);
+  if (!client) {
+    return;
+  }
+
+  return client.handlers[method] ?? vim.lsp.handlers[method];
+};


### PR DESCRIPTION
Closes #13. @ajitid Would you mind testing this out?

Should be good to go. I originally wrote my own handler but realized that hijacking Neovim's is better, since we'll also resolve any user-defined handlers and get multi-byte character handling out-of-the-box. Not sure if it's worth adding a test, since it's non-trivial to set up a situation where this doesn't behave identically to vanilla `Go to Definition`, but I'll think about it. 