### PR TITLE
feat(source definition): add fallback option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,21 @@ The following example shows all available options and their defaults:
 require("typescript").setup({
     disable_commands = false, -- prevent the plugin from creating Vim commands
     debug = false, -- enable debug logging for commands
+    go_to_source_definition = {
+        fallback = true, -- fall back to standard LSP definition on failure
+    },
     server = { -- pass options to lspconfig's setup method
         on_attach = ...,
     },
 })
 ```
 
-**Note:** if you have `require("lspconfig").setup({})` anywhere in your config,
-make sure to remove it and pass any options you were using under the `server`
-key. lspconfig doesn't allow more than one setup call, so your config will not
-work as expected.
+Note that command-specific configuration affects Vim commands, not the Lua API.
+
+**Important:** if you have `require("lspconfig").setup({})` anywhere in your
+config, make sure to remove it and pass any options you were using under the
+`server` key. lspconfig doesn't allow more than one setup call, so your config
+will not work as expected.
 
 ## Features
 
@@ -73,7 +78,7 @@ Lua commands.
   requires specifying the full path to a `source` and `target`.
 
 - Go to source definition: `:TypescriptGoToSourceDefinition` /
-  `require("typescript").goToSourceDefinition(winnr)`
+  `require("typescript").goToSourceDefinition(winnr, opts)`
 
   > TypeScript 4.7 contains support for a new experimental editor command called
   > Go To Source Definition. It’s similar to Go To Definition, but it never
@@ -84,6 +89,11 @@ Lua commands.
 
   The command requires a position and derives it from the current window when
   using the Vim command or from the given `winnr` when using the Lua API.
+
+  `opts` is a table containing the following options:
+
+  - `fallback`: determines whether to fall back to a standard LSP definition
+    request when the server fails to find a source definition.
 
 ### Handlers
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,3 +1,4 @@
+import { config } from "@ts/config";
 import { goToSourceDefinition } from "@ts/go-to-source-definition";
 import { renameFile } from "@ts/rename-file";
 import {
@@ -28,7 +29,10 @@ export const setupCommands = (bufnr: number): void => {
   vim.api.nvim_buf_create_user_command(
     bufnr,
     "TypescriptGoToSourceDefinition",
-    () => goToSourceDefinition({ winnr: vim.api.nvim_get_current_win() }),
+    () =>
+      goToSourceDefinition(vim.api.nvim_get_current_win(), {
+        fallback: config.go_to_source_definition.fallback,
+      }),
     {}
   );
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,9 @@ export interface ConfigOptions {
   disable_commands?: boolean;
   debug?: boolean;
   server?: NvimLsp.ServerOptions;
+  go_to_source_definition?: {
+    fallback: boolean;
+  };
 }
 
 class Config implements ConfigOptions {
@@ -9,8 +12,12 @@ class Config implements ConfigOptions {
   debug = false;
   server: NvimLsp.ServerOptions = {};
 
+  go_to_source_definition = {
+    fallback: true,
+  };
+
   setup(userOpts: ConfigOptions): void {
-    Object.assign(this, userOpts);
+    Object.assign(this, vim.tbl_deep_extend("force", this, userOpts));
   }
 }
 

--- a/src/go-to-source-definition.ts
+++ b/src/go-to-source-definition.ts
@@ -5,10 +5,13 @@ import { getClient, resolveHandler } from "@ts/utils";
 import { Location } from "vscode-languageserver-types";
 
 interface Opts {
-  winnr: number;
+  fallback?: boolean;
 }
 
-export const goToSourceDefinition = ({ winnr }: Opts): boolean => {
+export const goToSourceDefinition = (
+  winnr: number,
+  { fallback }: Opts
+): boolean => {
   const bufnr = vim.api.nvim_win_get_buf(winnr);
   const client = getClient(bufnr);
   if (!client) {
@@ -27,17 +30,26 @@ export const goToSourceDefinition = ({ winnr }: Opts): boolean => {
       arguments: [positionParams.textDocument.uri, positionParams.position],
     },
     (...args) => {
-      const res = args[1];
-      if (vim.tbl_isempty(res)) {
-        print("failed to go to source definition: no source definitions found");
-        return;
-      }
-
       const handler = resolveHandler(bufnr, Methods.DEFINITION);
       if (!handler) {
         print(
           "failed to go to source definition: could not resolve definition handler"
         );
+        return;
+      }
+
+      const res = args[1];
+      if (vim.tbl_isempty(res)) {
+        if (fallback === true) {
+          return client.request(
+            Methods.DEFINITION,
+            positionParams,
+            handler,
+            bufnr
+          );
+        }
+
+        print("failed to go to source definition: no source definitions found");
         return;
       }
 

--- a/src/types/nvim.d.ts
+++ b/src/types/nvim.d.ts
@@ -77,6 +77,11 @@ declare namespace vim {
   const inspect: (...args: unknown[]) => void;
   const schedule: (this: void, callback: () => void) => void;
   const tbl_isempty: (this: void, tbl: unknown[]) => boolean;
+  const tbl_deep_extend: <T>(
+    this: void,
+    behavior: "error" | "keep" | "force",
+    ...tables: T[]
+  ) => T;
   const lsp: {
     handlers: NvimLsp.Handlers;
     buf_get_clients: (


### PR DESCRIPTION
Follow-up to #27. While testing, I found that this was the behavior I always wanted, so I think it makes sense as a default, but I'm happy to hear opinions from anyone who happens to see this. This PR also quietly fixes the API method's signature to match the documentation. 

This change also required a couple of other changes to configuration resolution. I'd like to keep command-specific configuration in tables to avoid the unpleasant situation that naturally arose with nvim-lsp-ts-utils. 

I also went back and forth about whether to make command-specific configuration apply to the API, but ultimately I think it makes sense for Vim commands to "do what I mean" and for the API to "do what I say," so this PR also establishes that guideline.