### PR TITLE
feat: create parent directories on rename

### DIFF
--- a/lua/typescript/init.lua
+++ b/lua/typescript/init.lua
@@ -2724,6 +2724,11 @@ ____exports.renameFile = function(source, target, opts)
             return false
         end
     end
+    debugLog(("recursively creating parent dirs for rename (" .. target) .. ")")
+    vim.fn.mkdir(
+        vim.fn.fnamemodify(target, ":p:h"),
+        "p"
+    )
     debugLog((("sending request to rename source " .. source) .. " to target ") .. target)
     local requestOk = executeCommand(
         sourceBufnr,

--- a/src/rename-file.ts
+++ b/src/rename-file.ts
@@ -26,6 +26,9 @@ export const renameFile = (
     }
   }
 
+  debugLog(`recursively creating parent dirs for rename (${target})`);
+  vim.fn.mkdir(vim.fn.fnamemodify(target, ":p:h"), "p");
+
   debugLog(`sending request to rename source ${source} to target ${target}`);
   const requestOk = executeCommand(sourceBufnr, {
     command: WorkspaceCommands.APPLY_RENAME_FILE,

--- a/src/types/nvim.d.ts
+++ b/src/types/nvim.d.ts
@@ -167,6 +167,8 @@ declare namespace vim {
     const bufadd: (bufname: string) => number;
     const bufload: (bufnr: number) => void;
     const has: (feature: string) => 0 | 1;
+    const mkdir: (name: string, path?: string, prot?: number) => void;
+    const fnamemodify: (fname: string, mods: string) => string;
   }
 
   namespace loop {

--- a/test/spec/rename-file_spec.lua
+++ b/test/spec/rename-file_spec.lua
@@ -6,6 +6,8 @@ describe("renameFile", function()
 
     local old_path = path.join(test_utils.test_dir, "old-file.ts")
     local new_path = path.join(test_utils.test_dir, "new-file.ts")
+    local new_parent_dir = path.join(test_utils.test_dir, "new_dir")
+    local new_path_with_new_parent = path.join(new_parent_dir, "new-file.ts")
     local linked_path = path.join(test_utils.test_dir, "linked-file.ts")
 
     local file_content = [[
@@ -22,6 +24,8 @@ myFunc();]]
     after_each(function()
         vim.loop.fs_unlink(old_path)
         vim.loop.fs_unlink(new_path)
+        vim.loop.fs_unlink(new_path_with_new_parent)
+        vim.loop.fs_unlink(new_parent_dir)
         vim.loop.fs_unlink(linked_path)
     end)
 
@@ -35,6 +39,18 @@ myFunc();]]
         assert.truthy(path.exists(new_path))
         assert.equals(vim.api.nvim_buf_get_name(0), new_path)
         assert.equals(table.concat(vim.api.nvim_buf_get_lines(0, 0, -1, false), "\n"), file_content)
+    end)
+
+    it("creates parent directory and moves old file content into new file", function()
+        test_utils.write_file(old_path, file_content)
+        test_utils.edit_temp_file(old_path)
+
+        require("typescript").renameFile(old_path, new_path_with_new_parent)
+
+        assert.falsy(path.exists(old_path))
+        assert.truthy(path.exists(new_path_with_new_parent))
+        -- assert.equals(vim.api.nvim_buf_get_name(0), new_path_with_new_parent)
+        -- assert.equals(table.concat(vim.api.nvim_buf_get_lines(0, 0, -1, false), "\n"), file_content)
     end)
 
     it("updates path in linked file", function()


### PR DESCRIPTION
closes #47 

run `mkdir` to create parent directories for the target rename.