### PR TITLE
chore: update inlay hints doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ require("null_ls").setup({
 - How do I enable inlay hints?
   - Ensure you have installed Neovim >= v0.10.0. Inlay hints will not work in previous versions.
   - Enable the desired inlay hint options in the server settings, e.g.:
-  ```lua
+```lua
 require("typescript").setup({
   server = {
     settings={
@@ -167,7 +167,7 @@ require("typescript").setup({
     },
   },
 })
-  ```
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -137,11 +137,17 @@ require("null_ls").setup({
 
 - How do I enable inlay hints?
   - Ensure you have installed Neovim >= v0.10.0. Inlay hints will not work in previous versions.
-  - Enable the desired inlay hint options in the server settings, e.g.:
+  - Enable the `inlay_hint` option in your `on_attach` function **AND** set your desired settings in the server setup, e.g.:
 ```lua
 require("typescript").setup({
   server = {
+    on_attach = function(client, bufnr)
+      -- your other on_attach stuff here if you have any
+      -- ...
+      vim.lsp.buf.inlay_hint(bufnr, true)
+    end,
     settings={
+      -- specify some or all of the following settings if you want to adjust the default behavior
       javascript = {
         inlayHints = {
           includeInlayEnumMemberValueHints = true,

--- a/README.md
+++ b/README.md
@@ -129,14 +129,45 @@ require("null_ls").setup({
 })
 ```
 
-## Not yet implemented
-
-- Inlay hints (waiting for
-  [upstream support](https://github.com/neovim/neovim/issues/18086))
-
 ## Will not support
 
 - Anything not supported by `typescript-language-server` itself
+
+## FAQ
+
+- How do I enable inlay hints?
+  - Ensure you have installed Neovim >= v0.10.0. Inlay hints will not work in previous versions.
+  - Enable the desired inlay hint options in the server settings, e.g.:
+  ```lua
+require("typescript").setup({
+  server = {
+    settings={
+      javascript = {
+        inlayHints = {
+          includeInlayEnumMemberValueHints = true,
+          includeInlayFunctionLikeReturnTypeHints = true,
+          includeInlayFunctionParameterTypeHints = true,
+          includeInlayParameterNameHints = "all", -- 'none' | 'literals' | 'all';
+          includeInlayParameterNameHintsWhenArgumentMatchesName = true,
+          includeInlayPropertyDeclarationTypeHints = true,
+          includeInlayVariableTypeHints = true,
+        },
+      },
+      typescript = {
+        inlayHints = {
+          includeInlayEnumMemberValueHints = true,
+          includeInlayFunctionLikeReturnTypeHints = true,
+          includeInlayFunctionParameterTypeHints = true,
+          includeInlayParameterNameHints = "all", -- 'none' | 'literals' | 'all';
+          includeInlayParameterNameHintsWhenArgumentMatchesName = true,
+          includeInlayPropertyDeclarationTypeHints = true,
+          includeInlayVariableTypeHints = true,
+        },
+      },
+    },
+  },
+})
+  ```
 
 ## Contributing
 


### PR DESCRIPTION
- Removed not yet implemented section
- added FAQ section with guide for enabling inlay hints

If you have plans to more explicitly support inlay hints please feel free to close this, but I thought I'd update it since it seems to be causing confusion for some new users who are trying to use inlay hints with typescript (see #77)